### PR TITLE
feat: 회원가입 버그 fix, 로그인 shadcn 적용 및 로그인처리

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -48,6 +48,16 @@
             "position": "before"
           },
           {
+            "pattern": "@hooks",
+            "group": "internal",
+            "position": "before"
+          },
+          {
+            "pattern": "@hooks*",
+            "group": "internal",
+            "position": "before"
+          },
+          {
             "pattern": "@components",
             "group": "internal",
             "position": "before"

--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -1,3 +1,8 @@
+'use client';
+
+import { useEffect } from 'react';
+import { hasCookie } from 'cookies-next';
+import { useLogout } from '@hooks';
 import { HeadBar, Navigation, Post } from '@components';
 
 const data: {
@@ -37,6 +42,13 @@ const data: {
 ];
 
 export default function Home() {
+  const logout = useLogout();
+
+  useEffect(() => {
+    !hasCookie('access-token') ? logout() : null;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   return (
     <>
       <HeadBar />

--- a/app/signIn/page.tsx
+++ b/app/signIn/page.tsx
@@ -3,7 +3,7 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { setCookie } from 'cookies-next';
@@ -35,6 +35,7 @@ const SignInFormSchema = z.object({
 
 export default function SignInPage() {
   const router = useRouter();
+  const remember = useRef<HTMLButtonElement>(null);
   const [warning, setWarning] = useState(false);
 
   const SignInForm = useForm<z.infer<typeof SignInFormSchema>>({
@@ -60,6 +61,9 @@ export default function SignInPage() {
 
       const response = res.status === 200 ? await res.json() : {};
       if ('access-token' in response && 'refresh-token' in response) {
+        remember.current!.getAttribute('data-state') === 'checked'
+          ? setCookie('rememberMe', true)
+          : null;
         setCookie('access-token', response['access-token']);
         setCookie('refresh-token', response['refresh-token']);
         router.push('/');
@@ -128,17 +132,16 @@ export default function SignInPage() {
             )}
           />
 
-          <div className="pt-4" />
+          <div className="pt-8 pb-4 flex align-middle gap-1 w-full justify-start">
+            <Checkbox id="rememberLogin" ref={remember} />
+            <Label htmlFor="rememberLogin">Remember me</Label>
+          </div>
+
           <Button type="submit" className="h-12 w-full">
             Sign in
           </Button>
         </form>
       </Form>
-
-      <div className="flex align-middle gap-1 w-full justify-start">
-        <Checkbox id="rememberLogin" />
-        <Label htmlFor="rememberLogin">Remember me</Label>
-      </div>
 
       {warning ? (
         <div className="text-red-500">

--- a/app/signIn/page.tsx
+++ b/app/signIn/page.tsx
@@ -3,31 +3,49 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { useRef, useState } from 'react';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
 import { setCookie } from 'cookies-next';
+import { z } from 'zod';
 import { Button } from '@components/ui/button';
 import { Checkbox } from '@components/ui/checkbox';
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@components/ui/form';
 import { Input } from '@components/ui/input';
 import { Label } from '@components/ui/label';
 
+const SignInFormSchema = z.object({
+  email: z
+    .string()
+    .email({ message: '유효한 이메일을 입력해주세요.' })
+    .max(50, { message: '50자 이하로 입력해주세요.' }),
+  password: z
+    .string()
+    .min(6, { message: '6자이상 20자이하로 입력해주세요.' })
+    .max(20, { message: '6자이상 20자이하로 입력해주세요.' }),
+});
+
 export default function SignInPage() {
   const router = useRouter();
-  const [empty, setEmpty] = useState(false);
   const [warning, setWarning] = useState(false);
-  const email = useRef<HTMLInputElement>(null);
-  const password = useRef<HTMLInputElement>(null);
 
-  const reset = () => {
-    setEmpty(false);
-    setWarning(false);
-  };
+  const SignInForm = useForm<z.infer<typeof SignInFormSchema>>({
+    resolver: zodResolver(SignInFormSchema),
+    defaultValues: {
+      email: '',
+      password: '',
+    },
+  });
 
-  const signIn = async () => {
-    if (!email.current!.value || !password.current!.value) {
-      setEmpty(true);
-      return;
-    } else setEmpty(false);
-
+  const signInSubmit = async (data: z.infer<typeof SignInFormSchema>) => {
     try {
       const res = await fetch('/api/login', {
         method: 'post',
@@ -35,8 +53,8 @@ export default function SignInPage() {
           'Content-type': 'application/json',
         },
         body: JSON.stringify({
-          email: email.current!.value,
-          password: password.current!.value,
+          email: data.email,
+          password: data.password,
         }),
       });
 
@@ -51,38 +69,77 @@ export default function SignInPage() {
     }
   };
 
+  const reset = () => setWarning(false);
+
   return (
     <div className="flex flex-col p-8 gap-4 items-center">
       <Image src="/img/testPhoto.jpg" alt="logo" width={150} height={150} />
       <h2 className="text-2xl font-bold">Sign in</h2>
 
-      <Input
-        ref={email}
-        type="email"
-        placeholder="Email"
-        className="h-12"
-        onChange={reset}
-      />
-      <Input
-        ref={password}
-        type="password"
-        placeholder="password"
-        className="h-12"
-        onChange={reset}
-      />
+      <Form {...SignInForm}>
+        <form
+          onSubmit={SignInForm.handleSubmit(signInSubmit)}
+          onChange={reset}
+          className="w-full"
+        >
+          <FormField
+            control={SignInForm.control}
+            name="email"
+            render={({ field: { value, onChange } }) => (
+              <FormItem>
+                <FormLabel>Email</FormLabel>
+                <div className="flex gap-1">
+                  <FormControl>
+                    <Input
+                      placeholder="Email"
+                      value={value}
+                      onChange={onChange}
+                    />
+                  </FormControl>
+                </div>
+                <FormDescription>
+                  로그인시 사용할 이메일을 입력해주세요.
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <div className="pt-4" />
+          <FormField
+            control={SignInForm.control}
+            name="password"
+            render={({ field: { value, onChange } }) => (
+              <FormItem>
+                <FormLabel>Password</FormLabel>
+                <div className="flex gap-1">
+                  <FormControl>
+                    <Input
+                      type="password"
+                      placeholder="Password"
+                      value={value}
+                      onChange={onChange}
+                    />
+                  </FormControl>
+                </div>
+                <FormDescription>비밀번호를 입력해주세요</FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <div className="pt-4" />
+          <Button type="submit" className="h-12 w-full">
+            Sign in
+          </Button>
+        </form>
+      </Form>
 
       <div className="flex align-middle gap-1 w-full justify-start">
         <Checkbox id="rememberLogin" />
         <Label htmlFor="rememberLogin">Remember me</Label>
       </div>
 
-      <Button className="h-12 w-full" onClick={signIn}>
-        Sign in
-      </Button>
-
-      {empty ? (
-        <div className="text-red-500">아이디와 비밀번호를 입력해주세요.</div>
-      ) : null}
       {warning ? (
         <div className="text-red-500">
           아이디와 비밀번호를 다시 입력해주세요.

--- a/app/signUp/page.tsx
+++ b/app/signUp/page.tsx
@@ -150,10 +150,10 @@ export default function SignUpPage() {
   };
 
   const signUp = async () => {
-    if (email === '' || password === '' || name === '') {
+    if (!email || !password || !name) {
       setEmpty(true);
       return;
-    } else if (userName === '') {
+    } else if (!userName) {
       setUserNameCheck(false);
       return;
     }

--- a/app/signUp/page.tsx
+++ b/app/signUp/page.tsx
@@ -306,6 +306,7 @@ export default function SignUpPage() {
           />
         </form>
       </Form>
+
       {userNameDuplicate ? (
         <div className="text-red-500">이미 사용중인 닉네임입니다.</div>
       ) : null}

--- a/app/signUp/page.tsx
+++ b/app/signUp/page.tsx
@@ -142,6 +142,8 @@ export default function SignUpPage() {
     setEmailDescriptionReset(true);
   };
 
+  const passwordReset = () => setPassword('');
+
   const userNamenReset = () => {
     setUserName('');
     setUserNameDescriptionReset(true);
@@ -221,6 +223,7 @@ export default function SignUpPage() {
           onChange={() => {
             PasswordForm.handleSubmit(passwordSubmit)();
             reset();
+            passwordReset();
           }}
           className="w-full"
         >

--- a/components/headBar.tsx
+++ b/components/headBar.tsx
@@ -1,11 +1,14 @@
 'use client';
 
 import { usePathname } from 'next/navigation';
+import { useLogout } from '@hooks';
 import { Button } from './ui/button';
 
 export default function HeadBar() {
+  const logout = useLogout();
   const path = usePathname().split('/')[1];
   const title = path === '' ? 'home' : path;
+
   return (
     <div className="flex justify-between w-full h-16 items-center p-4 bg-primary z-50">
       <Button className="hover:bg-slate-500">{title}</Button>
@@ -13,6 +16,9 @@ export default function HeadBar() {
         <Button className="hover:bg-slate-500">chat</Button>
         <Button className="hover:bg-slate-500">search</Button>
         <Button className="hover:bg-slate-500">notice</Button>
+        <Button className="hover:bg-slate-500" onClick={logout}>
+          logout
+        </Button>
       </div>
     </div>
   );

--- a/hooks/index.tsx
+++ b/hooks/index.tsx
@@ -1,0 +1,1 @@
+export { default as useLogout } from './useLogout';

--- a/hooks/useLogout.tsx
+++ b/hooks/useLogout.tsx
@@ -1,0 +1,15 @@
+import { useRouter } from 'next/navigation';
+import { deleteCookie } from 'cookies-next';
+
+const useLogout = () => {
+  const router = useRouter();
+  const logout = () => {
+    deleteCookie('rememberMe');
+    deleteCookie('access-token');
+    deleteCookie('refresh-token');
+    router.push('/signIn');
+  };
+  return logout;
+};
+
+export default useLogout;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,8 @@
     ],
     "baseUrl": "./",
     "paths": {
+      "@hooks": ["hooks/index"],
+      "@hooks/*": ["hooks/*"],
       "@components": ["components/index"],
       "@components/*": ["components/*"],
       "@atoms": ["states/index"],


### PR DESCRIPTION
<!-- (주석) 모두가 보는 게시물입니다. 다른 사람도 이해 할 수 있는 언어로 작성해주시길 바랍니다!
- PR 이름은 다른 사람도 이해할 수 있는지
- 리뷰가 필요한 사람(Reviewers)을 추가했는지
- Assignees를 추가했는지
- 아래와 같이 작성
  - feat:
  - docs:
  - chore:
  - refactor:
  - fix:
- Labels에는 해당 PR의 성향을 잘 나타내나요?
 -->

- 빌드에러🈚

# Describe your changes

- 회원가입 버그 fix
- 로그인 `shadcn` 적용
- 로그아웃은 훅 제작
  - 로그아웃할 경우 `cookie`로 저장된 `access-token`, `refresh-token`, _(자동로그인을 선택했다면)_ `rememberMe`를 삭제
- 자동로그인 적용
  - 여기서 논의해봐야 할게, 쿠키로 값을 저장하면 자동로그인을 하지 않아도 쿠키 값이 남아있어서 항상 자동로그인이 돼요... 💦
  - 제가 생각하는 해결책은
    1. `access-token`, `refresh-token`은 항상 세션으로 저장하고, 자동로그인을 체크한 경우에만 쿠키에 `access-token`, `refresh-token`을 추가로 저장한다.
    2. 자동로그인 선택없이 우리 페이지는 항상 자동로그인^^
- 메인에서 `access-token`유무를 확인하고, 없다면 로그인화면으로 라우팅합니당
  - 이 과정으로 `use client`로 바뀌어서, 포스트 `seo` 적용은 post component를 따로 만들어야 할 듯 합니당,,🥹

<!-- 사진 있다면 첨부 -->

# Photo

<div align="center">
  <img src="https://github.com/SSOCK/Front/assets/96722691/e23cad4e-b8dc-41d7-a137-33a601aa846f">
  <img src="https://github.com/SSOCK/Front/assets/96722691/b211340a-3b11-4366-85bc-c6067fd1b4fb">
</div>

|자동로그인🆗|자동로그인❌|
|--|--|
|![image](https://github.com/SSOCK/Front/assets/96722691/7ebabf20-cb9d-41d2-8a54-6a0ae3713659)|![image](https://github.com/SSOCK/Front/assets/96722691/a3de57c7-72a4-4bda-8977-1676072221ee)|


<!-- 연결된 이슈가 있다면 close 해주기 -->

# Issue number and link

- closed #26 
