### PR TITLE
feat: 토큰 저장위치 변경, 401에러 처리, 자동로그인 처리 완료

### DIFF
--- a/app/(home)/[postid]/page.tsx
+++ b/app/(home)/[postid]/page.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { useEffect } from 'react';
+import { HeadBar, Navigation, Post } from '@components';
+import useLogout from '@hooks/useLogout';
+
+export default function Home() {
+  const logout = useLogout();
+
+  useEffect(() => {
+    if (!sessionStorage.getItem('access-token')) {
+      logout();
+    }
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <>
+      <HeadBar />
+      <Navigation />
+    </>
+  );
+}

--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -3,15 +3,22 @@
 import { useEffect } from 'react';
 import { HeadBar, Navigation, Post } from '@components';
 import useLogout from '@hooks/useLogout';
+import { refreshAccessToken } from '@/utils/fetch';
 import Posts from './posts';
 
 export default function Home() {
   const logout = useLogout();
 
   useEffect(() => {
-    if (!sessionStorage.getItem('access-token')) {
-      //logout();
-    }
+    const aa = async () => {
+      await refreshAccessToken();
+      console.log(sessionStorage.getItem('access-token'));
+
+      if (!sessionStorage.getItem('access-token')) {
+        logout();
+      }
+    };
+    aa();
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -10,7 +10,7 @@ export default function Home() {
 
   useEffect(() => {
     if (!sessionStorage.getItem('access-token')) {
-      logout();
+      //logout();
     }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/app/(home)/posts.tsx
+++ b/app/(home)/posts.tsx
@@ -1,31 +1,13 @@
 import { useEffect, useState } from 'react';
 import { Post } from '@components';
-import { tryAuthWithRefreshToken } from '@/utils/fetch';
+import { fetchWithRetry, getAccessToken } from '@/utils/fetch';
 
-async function getPost(): Promise<PostType[]> {
-  try {
-    const accessToken = sessionStorage.getItem('access-token');
-    if (!accessToken) throw new Error('access token이 없습니다!!');
-
-    const request = () =>
-      fetch('/api/posts?postid=1&limit=10', {
-        method: 'get',
-        headers: new Headers({
-          Authorization: accessToken,
-        }),
-      });
-    const response = await request();
-    if (response.status !== 200) {
-      throw response.status;
-    }
-
-    const data = await response.json();
-    return data;
-  } catch (error) {
-    console.log(error);
-    tryAuthWithRefreshToken();
-    return [];
-  }
+async function getPost() {
+  const url = '/api/posts?postid=1&limit=10';
+  const options = {
+    method: 'get',
+  };
+  return fetchWithRetry(url, options);
 }
 
 export default function Posts() {
@@ -33,12 +15,12 @@ export default function Posts() {
   async function loadPost() {
     const posts = await getPost();
     setData(posts);
-    console.log(data);
+    //console.log(posts);
   }
 
   useEffect(() => {
     loadPost();
-    console.log(data);
+    //console.log(data);
   }, []);
   return data.map((post, index) => <Post key={post.id} postData={post} />);
 }

--- a/app/signIn/page.tsx
+++ b/app/signIn/page.tsx
@@ -69,13 +69,13 @@ export default function SignInPage() {
         `Bearer ${response['access-token']}`
       );
       const cookieOptions = {
-        httpOnly: true,
+        //httpOnly: true,
         path: '/api/auth/refresh',
         ...(remember.current!.getAttribute('data-state') === 'checked' && {
           maxAge: 60 * 60 * 24 * 7,
         }),
       };
-      setCookie('refresh-token', response['refresh-token'], cookieOptions);
+      setCookie('refresh-token', `${response['refresh-token']}`, cookieOptions);
 
       router.push('/');
     } catch (error) {

--- a/app/signIn/page.tsx
+++ b/app/signIn/page.tsx
@@ -68,16 +68,14 @@ export default function SignInPage() {
         'access-token',
         `Bearer ${response['access-token']}`
       );
-      remember.current!.getAttribute('data-state') === 'checked'
-        ? setCookie('refresh-token', response['refresh-token'], {
-            maxAge: 60 * 60 * 24 * 7,
-            httpOnly: true,
-            path: '/api/auth/refresh',
-          })
-        : setCookie('refresh-token', response['refresh-token'], {
-            httpOnly: true,
-            path: '/api/auth/refresh',
-          });
+      const cookieOptions = {
+        httpOnly: true,
+        path: '/api/auth/refresh',
+        ...(remember.current!.getAttribute('data-state') === 'checked' && {
+          maxAge: 60 * 60 * 24 * 7,
+        }),
+      };
+      setCookie('refresh-token', response['refresh-token'], cookieOptions);
 
       router.push('/');
     } catch (error) {

--- a/components/post.tsx
+++ b/components/post.tsx
@@ -18,7 +18,6 @@ type PostProps = {
 };
 
 export default function Post({ postData }: PostProps) {
-  console.log(postData);
   return (
     <div className="w-full p-5">
       <div className="flex flex-col bg-slate-300 p-5 rounded-md shadow-xl">

--- a/hooks/useLogout.tsx
+++ b/hooks/useLogout.tsx
@@ -6,7 +6,7 @@ const useLogout = () => {
   const logout = () => {
     sessionStorage.removeItem('access-token');
     deleteCookie('refresh-token');
-    router.push('/signIn');
+    router.push('/signin');
   };
   return logout;
 };

--- a/utils/fetch.tsx
+++ b/utils/fetch.tsx
@@ -1,8 +1,39 @@
-export async function tryAuthWithRefreshToken() {
+export async function refreshAccessToken() {
   const respones = await fetch('/api/auth/refresh', {
     method: 'post',
     credentials: 'include',
   });
-  const data = await respones.json();
-  console.log(data);
+  if (respones.status !== 201) {
+    //실패시 처리
+    return;
+  }
+  if (!respones.ok) throw new Error('accessToken 재발급에 실패했습니다.');
+
+  const data: {
+    'access-token': string;
+  } = await respones.json();
+
+  sessionStorage.setItem('access-token', `Bearer ${data['access-token']}`);
+  return;
+}
+export async function fetchWithRetry(url: string, options: RequestInit) {
+  try {
+    options.headers = { ...options.headers, Authorization: getAccessToken() };
+    const respones = await fetch(url, options);
+    if (respones.ok) {
+      const data = await respones.json();
+      return data;
+    }
+    await refreshAccessToken();
+    options.headers = { ...options.headers, Authorization: getAccessToken() };
+    const respones2 = await fetch(url, options);
+    const data = await respones2.json();
+    return data;
+  } catch (error) {
+    console.error('fetch중 에러발생:', error);
+  }
+}
+
+export function getAccessToken() {
+  return sessionStorage.getItem('access-token') ?? 'no-token';
 }

--- a/utils/fetch.tsx
+++ b/utils/fetch.tsx
@@ -1,0 +1,8 @@
+export async function tryAuthWithRefreshToken() {
+  const respones = await fetch('/api/auth/refresh', {
+    method: 'post',
+    credentials: 'include',
+  });
+  const data = await respones.json();
+  console.log(data);
+}


### PR DESCRIPTION
<!-- (주석) 모두가 보는 게시물입니다. 다른 사람도 이해 할 수 있는 언어로 작성해주시길 바랍니다!
- PR 이름은 다른 사람도 이해할 수 있는지
- 리뷰가 필요한 사람(Reviewers)을 추가했는지
- Assignees를 추가했는지
- 아래와 같이 작성
  - feat:
  - docs:
  - chore:
  - refactor:
  - fix:
- Labels에는 해당 PR의 성향을 잘 나타내나요?
 -->

# Describe your changes

- 토큰 저장위치 변경
  - 기존
    - access, refresh 둘다 쿠키에
  - 변경
    - access: 세션스토리지, refresh: 쿠키 (httponly < 디버깅때문에 잠깐 빼놓음) 
  -  access토큰을 header Authorization으로 담아서 보내고 401시 refresh로 access token재발급 시도, 후에 재요청보냄
    - utils로 해당 함수 빼놓음

- 로그인여부 확인(자동로그인) 로직 변경
  - access token을 세션스토리지에 저장해서 기존 방식대로는 불가능(  브라우저 끄면 사라져서 )
  - 그래서 일단 홈페이지로 들어가면 refresh토큰으로 access토큰 발급시도함
    - 성공시 로그인됨
    - 실패시 로그인페이지로

<!-- 사진 있다면 첨부 -->

# Photo

<div align="center">
  <img src="">
</div>

<!-- 연결된 이슈가 있다면 close 해주기 -->

# Issue number and link

-
