### PR TITLE
refactor: header profile 분리, logout 변경

### DIFF
--- a/app/signin/page.tsx
+++ b/app/signin/page.tsx
@@ -60,7 +60,6 @@ export default function SignInPage() {
       });
 
       if (res.status !== 200) throw res.status;
-
       const response: { 'access-token': string; 'refresh-token': string } =
         await res.json();
       console.log('signin Done', response);

--- a/components/headBar.tsx
+++ b/components/headBar.tsx
@@ -23,9 +23,8 @@ export default function HeadBar() {
           </Button>
         </Link>
         {paths.map(({ path, category }) => (
-          <Link href={`/${path}`}>
+          <Link href={`/${path}`} key={category}>
             <Button
-              key={category}
               variant="link"
               className={cn([
                 'font-bold p-2 sm:p-4',

--- a/components/headBar.tsx
+++ b/components/headBar.tsx
@@ -1,12 +1,8 @@
-'use client';
-
 import Link from 'next/link';
-import { usePathname, useRouter } from 'next/navigation';
-import { ReactNode, useEffect, useRef, useState } from 'react';
+import { usePathname } from 'next/navigation';
 import { cn } from '@/lib/utils';
-import Add from '@/public/icons/add.svg';
-import Bell from '@/public/icons/bell.svg';
 import { Button } from './ui/button';
+import HeaderProfile from './headerProfile';
 
 const paths = [
   { path: '', category: '홈' },
@@ -17,35 +13,7 @@ const paths = [
 ];
 
 export default function HeadBar() {
-  const router = useRouter();
-
-  const [add, setAdd] = useState(false);
-  const [bell, setBell] = useState(false);
-  const [alarm, setAlarm] = useState<Array<ReactNode>>([]);
-  const addRef = useRef<HTMLDivElement>(null);
-  const bellRef = useRef<HTMLDivElement>(null);
-
   const nowPath = usePathname().split('/')[1];
-  const img = 'https://avatars.githubusercontent.com/u/96722691?v=5';
-  const elemClass = 'p-2 bg-white cursor-pointer hover:bg-border';
-  const alarmData = [
-    '알람 1입니다.',
-    '알람 2입니다.',
-    '알람 3입니다.',
-    '알람 4입니다.',
-  ];
-
-  useEffect(() => {
-    setAlarm(
-      alarmData.map((item, index) => (
-        <div key={index} className={elemClass}>
-          {item}
-        </div>
-      ))
-    );
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
   return (
     <div className="flex justify-between w-full h-16 items-center p-2 z-50 border-b xl:w-5/6 xl:mx-auto xl:p-4">
       <div>
@@ -65,53 +33,7 @@ export default function HeadBar() {
           </Button>
         ))}
       </div>
-
-      <div className="flex gap-3 sm:gap-5 sm:pr-4">
-        <div className="relative w-6 flex items-center">
-          <Add
-            className="w-full fill-primary cursor-pointer relative"
-            onClick={() => {
-              setBell(false);
-              bellRef.current!.style.display = 'none';
-              setAdd(!add);
-              addRef.current!.style.display = add ? 'none' : 'block';
-            }}
-          />
-          <div
-            ref={addRef}
-            className="hidden w-40 absolute top-9 right-0 border"
-          >
-            <div className={elemClass}>활동 기록</div>
-            <div className={elemClass}>코스 등록</div>
-            <div className={elemClass}>게시글 작성</div>
-          </div>
-        </div>
-
-        <div className="relative w-5 flex items-center">
-          <Bell
-            className="w-full cursor-pointer hover:fill-primary"
-            onClick={() => {
-              setAdd(false);
-              addRef.current!.style.display = 'none';
-              setBell(!bell);
-              bellRef.current!.style.display = bell ? 'none' : 'block';
-            }}
-          />
-          <div
-            ref={bellRef}
-            className="hidden w-56 absolute top-9 right-0 border"
-          >
-            {alarm}
-          </div>
-        </div>
-
-        <img
-          className="w-8 h-8 rounded-full border bg-slate-400 cursor-pointer"
-          src={img}
-          alt=""
-          onClick={() => router.push('/mypage')}
-        />
-      </div>
+      <HeaderProfile />
     </div>
   );
 }

--- a/components/headBar.tsx
+++ b/components/headBar.tsx
@@ -15,22 +15,26 @@ const paths = [
 export default function HeadBar() {
   const nowPath = usePathname().split('/')[1];
   return (
-    <div className="flex justify-between w-full h-16 items-center p-2 z-50 border-b xl:w-5/6 xl:mx-auto xl:p-4">
+    <div className="flex justify-between w-full h-16 items-center p-2 z-50 border-b xl:p-4">
       <div>
-        <Button variant="link" className="text-xl font-bold hidden sm:inline">
-          RunningMate
-        </Button>
-        {paths.map(({ path, category }) => (
-          <Button
-            key={category}
-            variant="link"
-            className={cn([
-              'font-bold p-2 sm:p-4',
-              nowPath !== path && 'text-black',
-            ])}
-          >
-            <Link href={`/${path}`}>{category}</Link>
+        <Link href={'/'}>
+          <Button variant="link" className="text-xl font-bold hidden sm:inline">
+            RunningMate
           </Button>
+        </Link>
+        {paths.map(({ path, category }) => (
+          <Link href={`/${path}`}>
+            <Button
+              key={category}
+              variant="link"
+              className={cn([
+                'font-bold p-2 sm:p-4',
+                nowPath !== path && 'text-black',
+              ])}
+            >
+              {category}
+            </Button>
+          </Link>
         ))}
       </div>
       <HeaderProfile />

--- a/components/headBar.tsx
+++ b/components/headBar.tsx
@@ -1,8 +1,8 @@
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { cn } from '@/lib/utils';
-import { Button } from './ui/button';
 import HeaderProfile from './headerProfile';
+import { Button } from './ui/button';
 
 const paths = [
   { path: '', category: '홈' },

--- a/components/headerProfile.tsx
+++ b/components/headerProfile.tsx
@@ -34,15 +34,13 @@ export default function HeaderProfile() {
 
   useEffect(() => {
     async function aa() {
-      // refresh토큰 있는지 검사해서 없으면
-      // console.log(hasCookie('refresh-token'));
-      // console.log(hasCookie('refresh-token', { path: '/api/auth/refresh' }));
-      // console.log(hasCookie('test', { path: '/test' }));
       const res = await fetchWithRetry('/api/member/profile/test', {
         method: 'get',
       });
+      if (!res?.ok) {
+        return;
+      }
       const data = (await res?.json()) as ProfileData;
-      console.log(data);
       //여기서 알람받아오는 api
       setProfileData(data);
       setAlarm(alarmData);

--- a/components/headerProfile.tsx
+++ b/components/headerProfile.tsx
@@ -3,9 +3,6 @@ import Add from '@/public/icons/add.svg';
 import Bell from '@/public/icons/bell.svg';
 import Link from 'next/link';
 import { fetchWithRetry, refreshAccessToken } from '@utils/fetch';
-import { hasCookie } from 'cookies-next';
-import { url } from 'inspector';
-import path from 'path';
 import { getAccessTokenPayload } from '@utils/token';
 
 interface ProfileData {
@@ -17,12 +14,9 @@ interface ProfileData {
 }
 
 export default function HeaderProfile() {
-  const [add, setAdd] = useState(false);
-  const [bell, setBell] = useState(false);
+  const [opendMenu, setOpenMenu] = useState<Number>(0);
   const [alarm, setAlarm] = useState<string[]>([]);
   const [profileData, setProfileData] = useState<ProfileData>();
-  const addRef = useRef<HTMLDivElement>(null);
-  const bellRef = useRef<HTMLDivElement>(null);
 
   const img = 'https://avatars.githubusercontent.com/u/96722691?v=5';
   const elemClass = 'p-2 bg-white cursor-pointer hover:bg-border';
@@ -36,7 +30,7 @@ export default function HeaderProfile() {
   useEffect(() => {
     async function aa() {
       try {
-        const refreshRes = await refreshAccessToken();
+        await refreshAccessToken();
         //토큰 발급 성공 (로그인 되어있거나, refreshtoken이 유효할때) 이제 access-token의 payload를 읽을 수 있음
         const payload = getAccessTokenPayload();
         const username = payload.username;
@@ -62,38 +56,33 @@ export default function HeaderProfile() {
     <>
       {profileData ? (
         <div className="flex gap-3 sm:gap-5 sm:pr-4">
-          <details
-            className="relative content-center"
-            onBlur={(e) => {
-              e.currentTarget.open = false;
-            }}
-          >
-            <summary className="text-[0]">
+          <div className="relative content-center">
+            <div onClick={() => setOpenMenu(opendMenu === 1 ? 0 : 1)}>
               <Add className="w-6 fill-primary cursor-pointer relative peer" />
-            </summary>
-            <div className=" w-40 absolute top-9 right-0 border ">
-              <div className={elemClass}>활동 기록</div>
-              <div className={elemClass}>코스 등록</div>
-              <div className={elemClass}>게시글 작성</div>
             </div>
-          </details>
-          <details
-            className="relative content-center"
-            onBlur={(e) => {
-              e.currentTarget.open = false;
-            }}
-          >
-            <summary className="text-[0]">
+            {opendMenu === 1 && (
+              <div className=" w-40 absolute top-9 right-0 border ">
+                <div className={elemClass}>활동 기록</div>
+                <div className={elemClass}>코스 등록</div>
+                <div className={elemClass}>게시글 작성</div>
+              </div>
+            )}
+          </div>
+          <div className="relative content-center">
+            <div onClick={() => setOpenMenu(opendMenu === 2 ? 0 : 2)}>
               <Bell className="w-6 cursor-pointer hover:fill-primary" />
-            </summary>
-            <div className="w-56 absolute top-9 right-0 border peer-checked:block">
-              {alarmData.map((item, index) => (
-                <div key={index} className={elemClass}>
-                  {item}
-                </div>
-              ))}
             </div>
-          </details>
+
+            {opendMenu === 2 && (
+              <div className="w-56 absolute top-9 right-0 border peer-checked:block">
+                {alarm.map((item, index) => (
+                  <div key={index} className={elemClass}>
+                    {item}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
 
           <Link href={'/mypage'}>
             <img
@@ -105,7 +94,7 @@ export default function HeaderProfile() {
         </div>
       ) : (
         <Link href={'/signin'}>
-          <h1>로그인 먼저 하세요</h1>
+          <h1>로그인 하세요</h1>
         </Link>
       )}
     </>

--- a/components/headerProfile.tsx
+++ b/components/headerProfile.tsx
@@ -3,6 +3,9 @@ import Add from '@/public/icons/add.svg';
 import Bell from '@/public/icons/bell.svg';
 import Link from 'next/link';
 import { fetchWithRetry } from '@utils/fetch';
+import { hasCookie } from 'cookies-next';
+import { url } from 'inspector';
+import path from 'path';
 
 interface ProfileData {
   id: number;
@@ -31,6 +34,10 @@ export default function HeaderProfile() {
 
   useEffect(() => {
     async function aa() {
+      // refresh토큰 있는지 검사해서 없으면
+      // console.log(hasCookie('refresh-token'));
+      // console.log(hasCookie('refresh-token', { path: '/api/auth/refresh' }));
+      // console.log(hasCookie('test', { path: '/test' }));
       const res = await fetchWithRetry('/api/member/profile/test', {
         method: 'get',
       });

--- a/components/headerProfile.tsx
+++ b/components/headerProfile.tsx
@@ -47,33 +47,38 @@ export default function HeaderProfile() {
     <>
       {profileData ? (
         <div className="flex gap-3 sm:gap-5 sm:pr-4">
-          <div className="relative w-6 flex items-center">
-            <input id="add" type="checkbox" className="hidden peer"></input>
-            <label htmlFor="add">
+          <details
+            className="relative content-center"
+            onBlur={(e) => {
+              e.currentTarget.open = false;
+            }}
+          >
+            <summary className="text-[0]">
               <Add className="w-6 fill-primary cursor-pointer relative peer" />
-            </label>
-
-            <div className="hidden w-40 absolute top-9 right-0 border peer-checked:block">
+            </summary>
+            <div className=" w-40 absolute top-9 right-0 border ">
               <div className={elemClass}>활동 기록</div>
               <div className={elemClass}>코스 등록</div>
               <div className={elemClass}>게시글 작성</div>
             </div>
-          </div>
-
-          <div className="relative w-5 flex items-center">
-            <input id="bell" type="checkbox" className="hidden peer"></input>
-            <label htmlFor="bell">
-              <Bell className="w-full cursor-pointer hover:fill-primary" />
-            </label>
-
-            <div className="hidden w-56 absolute top-9 right-0 border peer-checked:block">
+          </details>
+          <details
+            className="relative content-center"
+            onBlur={(e) => {
+              e.currentTarget.open = false;
+            }}
+          >
+            <summary className="text-[0]">
+              <Bell className="w-6 cursor-pointer hover:fill-primary" />
+            </summary>
+            <div className="w-56 absolute top-9 right-0 border peer-checked:block">
               {alarmData.map((item, index) => (
                 <div key={index} className={elemClass}>
                   {item}
                 </div>
               ))}
             </div>
-          </div>
+          </details>
 
           <Link href={'/mypage'}>
             <img

--- a/components/headerProfile.tsx
+++ b/components/headerProfile.tsx
@@ -1,9 +1,9 @@
-import { useState, useRef, useEffect } from 'react';
-import Add from '@/public/icons/add.svg';
-import Bell from '@/public/icons/bell.svg';
 import Link from 'next/link';
+import { useState, useEffect } from 'react';
 import { fetchWithRetry, refreshAccessToken } from '@utils/fetch';
 import { getAccessTokenPayload } from '@utils/token';
+import Add from '@/public/icons/add.svg';
+import Bell from '@/public/icons/bell.svg';
 
 interface ProfileData {
   id: number;
@@ -50,6 +50,7 @@ export default function HeaderProfile() {
       }
     }
     aa();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (

--- a/components/headerProfile.tsx
+++ b/components/headerProfile.tsx
@@ -42,29 +42,18 @@ export default function HeaderProfile() {
     }
     aa();
   }, []);
-  // console.log(res);
-  // setAlarm(
-  //
-  // );
 
   return (
     <>
       {profileData ? (
         <div className="flex gap-3 sm:gap-5 sm:pr-4">
           <div className="relative w-6 flex items-center">
-            <Add
-              className="w-full fill-primary cursor-pointer relative"
-              onClick={() => {
-                setBell(false);
-                bellRef.current!.style.display = 'none';
-                setAdd(!add);
-                addRef.current!.style.display = add ? 'none' : 'block';
-              }}
-            />
-            <div
-              ref={addRef}
-              className="hidden w-40 absolute top-9 right-0 border"
-            >
+            <input id="add" type="checkbox" className="hidden peer"></input>
+            <label htmlFor="add">
+              <Add className="w-6 fill-primary cursor-pointer relative peer" />
+            </label>
+
+            <div className="hidden w-40 absolute top-9 right-0 border peer-checked:block">
               <div className={elemClass}>활동 기록</div>
               <div className={elemClass}>코스 등록</div>
               <div className={elemClass}>게시글 작성</div>
@@ -72,19 +61,12 @@ export default function HeaderProfile() {
           </div>
 
           <div className="relative w-5 flex items-center">
-            <Bell
-              className="w-full cursor-pointer hover:fill-primary"
-              onClick={() => {
-                setAdd(false);
-                addRef.current!.style.display = 'none';
-                setBell(!bell);
-                bellRef.current!.style.display = bell ? 'none' : 'block';
-              }}
-            />
-            <div
-              ref={bellRef}
-              className="hidden w-56 absolute top-9 right-0 border"
-            >
+            <input id="bell" type="checkbox" className="hidden peer"></input>
+            <label htmlFor="bell">
+              <Bell className="w-full cursor-pointer hover:fill-primary" />
+            </label>
+
+            <div className="hidden w-56 absolute top-9 right-0 border peer-checked:block">
               {alarmData.map((item, index) => (
                 <div key={index} className={elemClass}>
                   {item}

--- a/components/headerProfile.tsx
+++ b/components/headerProfile.tsx
@@ -1,0 +1,111 @@
+import { useState, useRef, useEffect } from 'react';
+import Add from '@/public/icons/add.svg';
+import Bell from '@/public/icons/bell.svg';
+import Link from 'next/link';
+import { fetchWithRetry } from '@utils/fetch';
+
+interface ProfileData {
+  id: number;
+  email: string;
+  name: string;
+  profilePicture: string;
+  username: string;
+}
+
+export default function HeaderProfile() {
+  const [add, setAdd] = useState(false);
+  const [bell, setBell] = useState(false);
+  const [alarm, setAlarm] = useState<string[]>([]);
+  const [profileData, setProfileData] = useState<ProfileData>();
+  const addRef = useRef<HTMLDivElement>(null);
+  const bellRef = useRef<HTMLDivElement>(null);
+
+  const img = 'https://avatars.githubusercontent.com/u/96722691?v=5';
+  const elemClass = 'p-2 bg-white cursor-pointer hover:bg-border';
+  const alarmData = [
+    '알람 1입니다.',
+    '알람 2입니다.',
+    '알람 3입니다.',
+    '알람 4입니다.',
+  ];
+
+  useEffect(() => {
+    async function aa() {
+      const res = await fetchWithRetry('/api/member/profile/test', {
+        method: 'get',
+      });
+      const data = (await res?.json()) as ProfileData;
+      console.log(data);
+      //여기서 알람받아오는 api
+      setProfileData(data);
+      setAlarm(alarmData);
+    }
+    aa();
+  }, []);
+  // console.log(res);
+  // setAlarm(
+  //
+  // );
+
+  return (
+    <>
+      {profileData ? (
+        <div className="flex gap-3 sm:gap-5 sm:pr-4">
+          <div className="relative w-6 flex items-center">
+            <Add
+              className="w-full fill-primary cursor-pointer relative"
+              onClick={() => {
+                setBell(false);
+                bellRef.current!.style.display = 'none';
+                setAdd(!add);
+                addRef.current!.style.display = add ? 'none' : 'block';
+              }}
+            />
+            <div
+              ref={addRef}
+              className="hidden w-40 absolute top-9 right-0 border"
+            >
+              <div className={elemClass}>활동 기록</div>
+              <div className={elemClass}>코스 등록</div>
+              <div className={elemClass}>게시글 작성</div>
+            </div>
+          </div>
+
+          <div className="relative w-5 flex items-center">
+            <Bell
+              className="w-full cursor-pointer hover:fill-primary"
+              onClick={() => {
+                setAdd(false);
+                addRef.current!.style.display = 'none';
+                setBell(!bell);
+                bellRef.current!.style.display = bell ? 'none' : 'block';
+              }}
+            />
+            <div
+              ref={bellRef}
+              className="hidden w-56 absolute top-9 right-0 border"
+            >
+              {alarmData.map((item, index) => (
+                <div key={index} className={elemClass}>
+                  {item}
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <Link href={'/mypage'}>
+            <img
+              className="w-8 h-8 rounded-full border bg-slate-400 cursor-pointer"
+              src={img}
+              alt=""
+            />
+          </Link>
+        </div>
+      ) : (
+        <Link href={'/signin'}>
+          <h1>로그인 먼저 하세요</h1>
+        </Link>
+      )}
+    </>
+  );
+}

--- a/utils/fetch.tsx
+++ b/utils/fetch.tsx
@@ -19,6 +19,7 @@ export async function fetchWithRetry(url: string, options: RequestInit) {
   try {
     options.headers = { ...options.headers, Authorization: getAccessToken() };
     const response = await fetch(url, options);
+    console.log(response);
     if (response.status !== 401) return response;
 
     await refreshAccessToken();
@@ -26,7 +27,7 @@ export async function fetchWithRetry(url: string, options: RequestInit) {
     const response2 = await fetch(url, options);
     return response2;
   } catch (error) {
-    logout();
+    // logout(href);
   }
 }
 

--- a/utils/fetch.tsx
+++ b/utils/fetch.tsx
@@ -23,7 +23,6 @@ export async function fetchWithRetry(
   try {
     options.headers = { ...options.headers, Authorization: getAccessToken() };
     const response = await fetch(url, options);
-    console.log(response);
     if (response.status !== 401) return response;
 
     await refreshAccessToken();

--- a/utils/fetch.tsx
+++ b/utils/fetch.tsx
@@ -15,7 +15,11 @@ export async function refreshAccessToken() {
   return;
 }
 
-export async function fetchWithRetry(url: string, options: RequestInit) {
+export async function fetchWithRetry(
+  url: string,
+  options: RequestInit,
+  href?: string
+) {
   try {
     options.headers = { ...options.headers, Authorization: getAccessToken() };
     const response = await fetch(url, options);
@@ -27,7 +31,7 @@ export async function fetchWithRetry(url: string, options: RequestInit) {
     const response2 = await fetch(url, options);
     return response2;
   } catch (error) {
-    // logout(href);
+    logout(href);
   }
 }
 

--- a/utils/logout.tsx
+++ b/utils/logout.tsx
@@ -1,9 +1,9 @@
 import { deleteCookie } from 'cookies-next';
 
-const logout = () => {
+const logout = (href?: string) => {
   sessionStorage.removeItem('access-token');
   deleteCookie('refresh-token');
-  window.location.href = '/signin';
+  if (href) window.location.href = href;
 };
 
 export default logout;

--- a/utils/token.tsx
+++ b/utils/token.tsx
@@ -1,0 +1,20 @@
+export function getAccessTokenPayload() {
+  const token = window.sessionStorage
+    .getItem('access-token')
+    ?.split(' ')
+    .pop() as string;
+  if (!token) throw new Error('access-token이 존재하지 않습니다');
+  const base64Payload = token.split('.')[1]; // jwt = header.payload.signature형식
+  const base64 = base64Payload.replace(/-/g, '+').replace(/_/g, '/');
+  const decodedJWT = JSON.parse(
+    decodeURIComponent(
+      window
+        .atob(base64)
+        .split('')
+        .map((c) => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2))
+        .join('')
+    )
+  ) as { sub: 'string'; username: string; exp: number };
+
+  return decodedJWT;
+}


### PR DESCRIPTION
<!-- (주석) 모두가 보는 게시물입니다. 다른 사람도 이해 할 수 있는 언어로 작성해주시길 바랍니다!
- PR 이름은 다른 사람도 이해할 수 있는지
- 리뷰가 필요한 사람(Reviewers)을 추가했는지
- Assignees를 추가했는지
- 아래와 같이 작성
  - feat:
  - docs:
  - chore:
  - refactor:
  - fix:
- Labels에는 해당 PR의 성향을 잘 나타내나요?
 -->

# Describe your changes

- headerBar에서 headerProfile분리, api연동
- logout변경으로 인해 fetchWithRetry함수에 api요청 실패시 redirection시켜줄 주소 넘겨줄 수 있도록 변경
  - 비로그인으로 볼 수있는 페이지도 있어서 바꿈
  - 넘겨주지 않으면 새로고침x 이동x 주의
- header 양옆이 잘려서 xl: margin 관련 클래스삭제
- 장염 치유 완료
![image](https://github.com/user-attachments/assets/7b284408-ac41-4ef2-bcc0-c7027dbc212a)
- jwt token payload decoding  util함수 구현
  - https://velog.io/@dohaeng0/base64-vs-base64-url-safe-%EA%B7%B8%EB%A6%AC%EA%B3%A0-%EC%98%88%EC%A0%9C
  - https://velog.io/@xxyeon129/JWT-decoding%ED%95%98%EA%B8%B0JavaScript
  - 참고하세요~
<!-- 사진 있다면 첨부 -->

# Photo

외관상 변화는 없슴두~
<div align="center">
  <img src="">
</div>

<!-- 연결된 이슈가 있다면 close 해주기 -->

# Issue number and link

-
